### PR TITLE
force enable dev tools within iframes

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -25,11 +25,13 @@
   "content_scripts": [
     {
       "matches": ["<all_urls>"],
+      "all_frames": true,
       "js": ["inject.js"],
       "run_at": "document_start"
     },
     {
       "matches": ["<all_urls>"],
+      "all_frames": true,
       "js": ["detector.js"],
       "run_at": "document_idle"
     }


### PR DESCRIPTION
If your vue code is inside an iframe, this extension does not work because it doesn't inject its script into the iframe. The `all_frames` setting controls whether or not the extension runs in iframes. See documentation: https://developer.chrome.com/docs/extensions/mv3/content_scripts/#frames